### PR TITLE
Corrección Archivo COVID-19 (CUT en dos comunas)

### DIFF
--- a/input/Covid-19.csv
+++ b/input/Covid-19.csv
@@ -328,10 +328,10 @@ Aisen,11,Aisen,11201,25002,-,-,4,5,4,16.0
 Aisen,11,Chile Chico,11401,5121,-,-,-,-,-,19.5
 Aisen,11,Cisnes,11202,5828,-,-,-,-,-,0.0
 Aisen,11,Cochrane,11301,3685,-,-,-,-,-,0.0
-Aisen,11,Coyhaique,,61210,-,-,-,-,-,1.6
+Aisen,11,Coyhaique,11101,61210,-,-,-,-,-,1.6
 Aisen,11,Guaitecas,11203,1599,-,-,-,-,-,0.0
 Aisen,11,Lago Verde,11102,920,-,-,-,-,-,0.0
-Aisen,11,OHiggins,,661,-,-,-,-,-,0.0
+Aisen,11,OHiggins,11302,661,-,-,-,-,-,0.0
 Aisen,11,Rio Ibanez,11402,2699,-,-,-,-,-,0.0
 Aisen,11,Tortel,11303,572,-,-,-,-,-,174.8
 Magallanes y la Antartica,12,Antartica,12202,137,-,-,-,-,-,0.0


### PR DESCRIPTION
Se corrige archivo COVID-19.csv el cual no puede unir con dos comunas (Coyhaique y O'higgins) por que no tenían Código único territorial