### PR TITLE
updated cuarentenas totales al 20200909, y readme.md

### DIFF
--- a/output/producto29/Cuarentenas-Totales.csv
+++ b/output/producto29/Cuarentenas-Totales.csv
@@ -1,108 +1,123 @@
-ID,Nombre,Estado,Alcance,Fecha de Inicio,Fecha de Término,Código CUT Comuna,Detalle,Superficie en m2,Perímetro en m
-1,Arica,Histórica,Área Urbana Completa,2020-04-16 22:00:00,2020-05-15 22:00:00,15101,Corresponde al Radio Urbano de la Ciudad de Arica incluyendo la población San Miguel de Azapa,28050418.8017578,48722.3000133714
-2,Santiago Norte,Histórica,Sector Específico,2020-04-13 05:00:00,2020-05-05 22:00:00,13101,Corresponde a la extensión de la cuarentena en la comuna de Santiago con límite en la línea contínua de las calles Av.Matta y Blanco Encalada,19939218.5703125,21599.3513430565
-3,Puente Alto Poniente,Histórica,Sector Específico,2020-04-09 22:00:00,2020-05-08 22:00:00,13201,Corresponde al sector delimitado por la Av. Concha y Toro hacia el poniente. Se extiende posterior al término hacia el oriente hasta el Canal San Carlos,42364268.2128906,30428.0515226124
-4,El Bosque,Activa,Comuna completa,2020-04-16 22:00:00,,13105,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,20622713.2285156,18788.8707505944
-5,San Bernardo Nororiente,Histórica,Sector Específico,2020-04-16 22:00:00,2020-05-08 22:00:00,13401,"Corresponde al sector delimitado por los limites comunales y al interior en Av. Colon, Av. Balmaceda y Autopista Central. Se extiende alcance de cuarentena a la linea comprendida entre Camino el Mariscal y Avenida San Jose",16326216.8320313,24929.1457196278
-6,Chillán,Histórica,Área Urbana Completa,2020-03-30 21:00:00,2020-04-23 22:00:00,16101,Aplica solo hasta el límite urbano de la ciudad,37835429.3652344,49337.0245698048
-7,Osorno,Histórica,Área Urbana Completa,2020-03-30 21:00:00,2020-04-30 22:00:00,10301,Aplica solo hasta el límite urbano de la ciudad,42268789.140625,59804.1628428391
-8,Punta Arenas,Histórica,Área Urbana Completa,2020-04-01 21:00:00,2020-05-07 22:00:00,12101,Aplica a la zona urbana de la ciudad de Punta Arenas,112704517.082031,77228.2048966254
-9,Nueva Imperial,Histórica,Área Urbana Completa,2020-04-09 22:00:00,2020-04-16 00:00:00,9111,Aplica solo hasta el límite urbano de la ciudad,5981050.97265625,16614.8223828867
-10,Lo Barnechea,Histórica,Área Urbana Completa,2020-03-26 21:00:00,2020-04-13 05:00:00,13115,Aplica solo hasta el límite urbano de la ciudad,94313826.9765625,56084.0080581568
-11,Vitacura,Histórica,Comuna completa,2020-03-26 21:00:00,2020-04-13 05:00:00,13132,Aplicada a la totalidad de la comuna,40092348.3808594,30500.0584721527
-12,Las Condes,Histórica,Comuna completa,2020-03-26 21:00:00,2020-04-16 22:00:00,13114,Aplicada a la totalidad de la comuna,144758812.964844,60443.7678527491
-13,Providencia,Histórica,Comuna completa,2020-03-26 21:00:00,2020-04-13 05:00:00,13123,Aplicada a la totalidad de la comuna,20592014.8867188,19208.8849554496
-14,Ñuñoa Norte,Histórica,Sector Específico,2020-04-13 05:00:00,2020-05-07 22:00:00,13120,Corresponde a la extensión de la cuarentena en la comuna de Ñuñoa con límite en Av. Grecia,16724738.7617188,19686.6745151636
-15,Hualpén,Histórica,Área Urbana Completa,2020-03-30 21:00:00,2020-04-16 22:00:00,8112,Aplica solo hasta el límite urbano de la ciudad,18355421.2773438,29232.3539224558
-16,San Pedro de la Paz,Histórica,Área Urbana Completa,2020-03-30 21:00:00,2020-04-16 22:00:00,8108,Aplica solo hasta el límite urbano de la ciudad,44074427.2617188,57975.6829409948
-17,Temuco,Histórica,Área Urbana Completa,2020-03-28 21:00:00,2020-04-30 22:00:00,9101,Aplica solo hasta el límite urbano de la ciudad,101423669.535156,129552.626170396
-18,Santiago,Histórica,Comuna completa,2020-03-26 21:00:00,2020-04-13 05:00:00,13101,Aplicada a la totalidad de la comuna,33432633.3222656,28873.1965573873
-19,Ñuñoa,Histórica,Comuna completa,2020-03-26 21:00:00,2020-04-13 05:00:00,13120,Aplicada a la totalidad de la comuna,24305861.1191406,21540.5882083678
-20,Chillán viejo,Histórica,Área Urbana Completa,2020-03-30 21:00:00,2020-04-23 22:00:00,16103,Aplica solo hasta el límite urbano de la ciudad,10541904.53125,16827.6726350142
-21,Padre Las Casas,Histórica,Área Urbana Completa,2020-03-27 23:00:00,2020-04-16 00:00:00,9112,Aplica solo hasta el límite urbano de la ciudad,11026951.7929688,16203.4065525269
-22,Rapa Nui,Histórica,Comuna completa,2020-03-19 23:00:00,2020-04-06 05:00:00,5201,Aplicada a la totalidad de la comuna,205901011.117188,79899.0823228499
-23,Independencia,Histórica,Comuna completa,2020-03-26 21:00:00,2020-04-02 21:00:00,13108,Aplicada a la totalidad de la comuna,10582914.0410156,13699.9128448973
-24,Puerto Williams,Histórica,Área Urbana Completa,2020-03-22 23:00:00,2020-04-06 05:00:00,12201,Aplica solo hasta el límite urbano de la ciudad,2973458.34765625,9302.18440182724
-25,Caleta Tortel,Histórica,Sector Específico,2020-03-12 21:00:00,2020-03-27 21:00:00,11303,Aplicada a la localidad de Caleta Tortel de forma preventiva por brotes de COVID-19 en Aysén,15336560.5195313,25455.5653612886
-26,Quinta Normal,Activa,Comuna completa,2020-04-23 22:00:00,,13126,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,17014139.1523438,21243.797016579
-27,Pedro Aguirre Cerda,Activa,Comuna completa,2020-04-23 22:00:00,,13121,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,12625146.265625,15651.7189634514
-28,Independencia Sur (Re-ingreso),Histórica,Sector Específico,2020-04-23 22:00:00,2020-04-30 22:00:00,13108,"Corresponde al sector delimitado por la linea comprendida de las calles Gamero y Santos Dumont hacia el sur, se extiende a cuarentena total el 30 de abril",2460063.44140625,8284.04113571919
-29,Victoria,Histórica,Área Urbana Completa,2020-04-30 22:00:00,2020-05-15 22:00:00,9211,Aplica solo hasta el límite urbano de la ciudad,9256998.9140625,36013.0185048258
-30,Angol,Histórica,Área Urbana Completa,2020-04-30 22:00:00,2020-05-15 22:00:00,9201,Aplica solo hasta el límite urbano de la ciudad,16903887.625,56627.2046086798
-31,San Ramon Sur,Histórica,Sector Específico,2020-04-30 22:00:00,2020-05-08 22:00:00,13131,Se aplica cuarentena en sector sur de la comuna delimitado por la Avenida Américo Vespucio. Se extiende posterior al término a una cuarentena de territorio completo,4606059.17382813,8714.79986943619
-32,Estación Central,Activa,Comuna completa,2020-04-30 22:00:00,,13106,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,20682566.4921875,22689.2274650058
-33,Independencia Extensión a Total,Activa,Comuna completa,2020-04-30 22:00:00,,13108,Aplicada a la totalidad de la comuna. Extendida desde el sector sur a la comuna completa. Se incorpora a cuarentena del Gran Santiago,10582914.0429688,13699.9128448926
-34,La Pintana Norte,Histórica,Sector Específico,2020-04-30 22:00:00,2020-05-08 22:00:00,13112,Se aplica cuarentena en el sector norte de la comuna delimitado por la Avenida el Observatorio hacia el norte. . Se extiende posterior al término a una cuarentena de territorio completo,4883155.13476563,12416.9778362389
-35,Antofagasta,Histórica,Área Urbana Completa,2020-05-05 22:00:00,2020-05-29 22:00:00,2101,Aplica solo hasta el límite urbano de la ciudad,43532156.4257813,134484.167871907
-36,Mejillones,Histórica,Comuna completa,2020-05-05 22:00:00,2020-05-29 22:00:00,2102,Aplicada a la totalidad de la comuna,4230181342.99414,395409.359038385
-37,Recoleta,Activa,Comuna completa,2020-05-05 22:00:00,,13127,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,22715640.5234375,22324.0747754827
-38,Cerrillos,Activa,Comuna completa,2020-05-05 22:00:00,,13102,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,24198337.6621094,25227.7694753954
-39,Quilicura,Histórica,Sector Específico,2020-05-05 22:00:00,2020-05-15 22:00:00,13125,Delimitada por la linea ferroviaria que cruza la comuna hacia el poniente. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,60071059.15625,32915.9895053343
-40,Santiago Extensión a Total,Activa,Comuna completa,2020-05-05 22:00:00,,13101,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,33329909.4960938,29265.4336900164
-41,Cerro Navia,Activa,Comuna completa,2020-05-08 22:00:00,,13103,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,15975127.9863281,19974.248542906
-42,Conchalí,Activa,Comuna completa,2020-05-08 22:00:00,,13104,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,15979605.8085938,16815.7934099155
-43,Lo Espejo,Activa,Comuna completa,2020-05-08 22:00:00,,13116,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,11886614.0898438,13762.0736724309
-44,La Cisterna,Activa,Comuna completa,2020-05-08 22:00:00,,13109,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,14401733.5859375,15356.421889586
-45,La Florida,Activa,Comuna completa,2020-05-08 22:00:00,,13110,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,102214162.755859,59430.2695012662
-46,Peñalolen,Activa,Comuna completa,2020-05-08 22:00:00,,13122,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,77293355.8457031,43926.3659584545
-47,Lo Prado,Activa,Comuna completa,2020-05-08 22:00:00,,13117,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,9448923.36523438,12856.5022905017
-48,Macul,Activa,Comuna completa,2020-05-08 22:00:00,,13118,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,18517268.578125,18417.8115619807
-49,Renca,Activa,Comuna completa,2020-05-08 22:00:00,,13128,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,34181427.8125,34681.9394332968
-50,San Joaquín,Activa,Comuna completa,2020-05-08 22:00:00,,13129,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,14337674.6074219,16946.3826485334
-51,San Miguel,Activa,Comuna completa,2020-05-08 22:00:00,,13130,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,13863805.7050781,16029.8040021794
-52,La Granja,Activa,Comuna completa,2020-05-08 22:00:00,,13111,Aplicada a la totalidad de la comuna. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,14562829.4550781,16986.3556262322
-53,La Pintana Extensión a Total,Activa,Comuna completa,2020-05-08 22:00:00,,13112,Se amplía a toda la comuna desde su extensión original. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,44005772.3105469,31961.0278584575
-54,San Ramón Extensión a Total,Activa,Comuna completa,2020-05-08 22:00:00,,13131,Se amplía a toda la comuna desde su extensión original. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,9061336.23046875,14097.9605564344
-55,Puente Alto Poniente Extendido,Histórica,Sector Específico,2020-05-08 22:00:00,2020-05-15 22:00:00,13201,Se amplia desde el límite actual (Av. Concha y Toro) hacia el oriente con límite en el Canal San Carlos. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,89693170.625,58094.3823765891
-56,San Bernardo Nororiente Extendido,Histórica,Sector Específico,2020-05-08 22:00:00,2020-05-15 22:00:00,13401,"Corresponde al sector delimitado por los limites comunales y al interior a la linea comprendida entre Camino el Mariscal y Avenida San Jose, Av. Balmaceda y Autopista Central. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago",22289080.8828125,27208.6722808201
-57,Alto Hospicio,Activa,Comuna completa,2020-05-15 22:00:00,,1107,Aplicada a la totalidad de la comuna,655133931.175781,109806.644974769
-58,Iquique,Activa,Comuna completa,2020-05-15 22:00:00,,1101,Aplicada a la totalidad de la comuna,2636677588.45313,473982.696822035
-59,Buin,Activa,Comuna completa,2020-05-15 22:00:00,,13402,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,315447694.376953,106661.453928384
-60,Pudahuel,Activa,Comuna completa,2020-05-15 22:00:00,,13124,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,283948656.376953,86170.5795723086
-61,Colina,Histórica,Comuna completa,2020-05-15 22:00:00,2020-07-28 05:00:00,13301,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,1388393075.82031,206066.838439161
-62,Lampa,Activa,Comuna completa,2020-05-15 22:00:00,,13302,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,645813313.240234,127669.572849804
-63,Huechuraba,Activa,Comuna completa,2020-05-15 22:00:00,,13107,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,64546615.3515625,39133.1212126811
-64,Las Condes Re-ingreso Total,Histórica,Comuna completa,2020-05-15 22:00:00,2020-07-28 05:00:00,13114,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,142593822.224609,62012.7380642498
-65,La Reina,Histórica,Comuna completa,2020-05-15 22:00:00,2020-07-28 05:00:00,13113,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,33764086.1796875,28525.5270919057
-66,Lo Barnechea Re-ingreso total,Histórica,Comuna completa,2020-05-15 22:00:00,2020-07-28 05:00:00,13115,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,1469176023.56641,179591.206411362
-67,Vitacura Re-ingreso Total,Histórica,Comuna completa,2020-05-15 22:00:00,2020-07-28 05:00:00,13132,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,40872314.0898438,31136.2480827119
-68,Maipú,Activa,Comuna completa,2020-05-15 22:00:00,,13119,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,198564410.646484,73872.6258555928
-69,Ñuñoa Re-ingreso Total,Histórica,Comuna completa,2020-05-15 22:00:00,2020-07-28 05:00:00,13120,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,24288323.7734375,21382.6382684562
-70,Padre Hurtado,Activa,Comuna completa,2020-05-15 22:00:00,,13604,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,117050934.980469,61176.6714847736
-71,Puente Alto Extensión a Total,Activa,Comuna completa,2020-05-15 22:00:00,,13201,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,127531919.042969,59827.7119649119
-72,Quilicura Extensión a Total,Activa,Comuna completa,2020-05-15 22:00:00,,13125,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,82391551.0488281,41916.2560534792
-73,San Bernardo Extensión a Total,Activa,Comuna completa,2020-05-15 22:00:00,,13401,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,221119742.068359,103398.390100715
-74,Providencia Re-ingreso total,Activa,Comuna completa,2020-05-15 22:00:00,,13123,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,20727385.15625,19429.199340283
-75,Lonquimay,Histórica,Comuna completa,2020-05-22 22:00:00,2020-06-05 22:00:00,9205,Aplicada a la totalidad por criterios de capacidad sanitaria y aumento sustantivo de casos,6426178803.84766,454701.679855686
-76,San Antonio,Histórica,Comuna completa,2020-06-09 22:00:00,2020-07-28 05:00:00,5601,Aplicada a la totalidad de la comuna,576482915.402344,154571.506097539
-77,Calama,Activa,Comuna completa,2020-06-12 22:00:00,,2201,Aplicada a la totalidad de la comuna,18278946180.584,705723.838225614
-78,Viña del Mar,Activa,Comuna completa,2020-06-12 22:00:00,,5109,Aplicada a la totalidad de la comuna,171902397.738281,77155.8975512116
-79,Valparaíso,Activa,Comuna completa,2020-06-12 22:00:00,,5101,Aplicada a la totalidad de la comuna,451856991.105469,181454.80909984
-80,Pozo Almonte (Radio Urbano),Activa,Área Urbana Completa,2020-06-12 22:00:00,,1401,Aplicable solo a la zona urbana,2353288.24023438,15497.7725966503
-81,San José de Maipo (Área Urbana),Activa,Área Urbana Completa,2020-06-12 22:00:00,,13203,Aplicado solo al sector urbano entre el Estero El Almendro y el Estero San José,6372625.9296875,11333.7834773233
-82,Melipilla (Área Urbana),Activa,Área Urbana Completa,2020-06-12 22:00:00,,13501,Aplicable solo al centro urbano,14510740.2324219,62602.7048087187
-83,Curacaví (Área Urbana),Activa,Área Urbana Completa,2020-06-12 22:00:00,,13503,Aplicable solo al Centro Urbano,5514002.38476563,32755.134785762
-84,TilTil (Área Urbana),Histórica,Área Urbana Completa,2020-06-12 22:00:00,2020-07-28 05:00:00,13303,"Aplicable solo a la zona urbana de Til-Til, excluyendo el sector de Huertos Familiares",1906761.89257813,18048.1205770965
-85,Peñaflor,Activa,Comuna completa,2020-06-12 22:00:00,,13605,Aplicada a la totalidad de la comuna,100223974.589844,46938.4971703687
-86,Los Andes,Activa,Comuna completa,2020-06-19 22:00:00,,5301,Aplicada a la totalidad de la comuna,1757629850.23828,274656.693977739
-87,San Felipe,Histórica,Comuna completa,2020-06-19 22:00:00,2020-07-28 05:00:00,5701,Aplicada a la totalidad de la comuna,264868542.685547,115232.849294407
-88,Rancagua,Activa,Comuna completa,2020-06-19 22:00:00,,6101,Aplicada a la totalidad de la comuna,382965176.1875,98686.2315737476
-89,Machalí,Activa,Comuna completa,2020-06-19 22:00:00,,6108,Aplicada a la totalidad de la comuna,3813690684.08398,346676.467677033
-90,Curicó (Área Urbana),Activa,Área Urbana Completa,2020-06-19 22:00:00,,7301,Aplicado solamente a la zona urbana,32069120.2851563,29295.2099611109
-91,Antofagasta Re-ingreso Ciudad,Activa,Área Urbana Completa,2020-06-23 22:00:00,,2101,Re-ingreso total por incremento de casos activos. Alcance urbano acorde a Res.Ex. MINSAL 479/2020 ,43532156.4257813,134484.167871907
-92,Mejillones Re-ingreso urbano,Activa,Área Urbana Completa,2020-06-23 22:00:00,,2102,Re-ingreso total por incremento de casos activos. Alcance solo a área urbana acorde a Res.Ex. MINSAL 479/2020 ,7391563.77148438,35405.5396978546
-93,Tocopilla,Activa,Área Urbana Completa,2020-06-23 22:00:00,,2301,Aplicada solo a la extensión urbana de la comuna conforme a Res.Ex. MINSAL 479/2020,5375471.3125,31002.8841710106
-94,Quillota,Activa,Comuna completa,2020-06-26 22:00:00,,5501,Aplicada a la totalidad de la comuna,428867542.921875,107405.438297665
-95,Graneros,Activa,Comuna completa,2020-06-26 22:00:00,,6106,Aplicada a la totalidad de la comuna,164012497.722656,67214.9793907091
-96,Calera de Tango,Activa,Comuna completa,2020-06-26 22:00:00,,13403,Aplicada a la totalidad de la comuna,105783369.845703,54220.9928795631
-97,El Monte,Activa,Comuna completa,2020-06-26 22:00:00,,13602,Aplicada a la totalidad de la comuna,166257629.505859,59682.0347698489
-98,Talagante,Activa,Comuna completa,2020-06-26 22:00:00,,13601,Aplicada a la totalidad de la comuna,183307247.0,81310.1022562255
-99,Arica Re-Ingreso urbano,Activa,Área Urbana Completa,2020-07-14 22:00:00,,15101,Corresponde al Re-ingreso del Radio Urbano de la Ciudad de Arica,28050418.8046875,48722.3000133759
-100,Rengo,Activa,Comuna completa,2020-07-14 22:00:00,,6115,Aplicada a la totalidad de la comuna de forma indefinida,861965138.042969,201937.442359106
-101,Copiapó,Activa,Comuna completa,2020-07-27 22:00:00,,3101,Aplicada a la totalidad de la comuna de forma indefinida,22625013803.1387,1406885.40093402
-102,La Calera,Activa,Comuna completa,2020-07-27 22:00:00,,5502,Aplicada a la totalidad de la comuna,84139819.6757813,67738.4324019953
-103,La Cruz,Activa,Comuna completa,2020-07-27 22:00:00,,5504,Aplicada a la totalidad de la comuna de forma indefinida,110927483.525391,57942.953712829
-104,Isla de Maipo,Activa,Comuna completa,2020-07-27 22:00:00,,13603,Aplicada a la totalidad de la comuna de forma indefinida,274564570.140625,96196.0438396968
-105,Puerto Montt,Activa,Comuna completa,2020-07-27 22:00:00,,10101,Aplicada a la totalidad de la comuna de forma indefinida,2985602290.16016,527212.90641785
-106,La Serena,Activa,Comuna completa,2020-07-27 22:00:00,,4101,Aplicada a la totalidad de la comuna de forma indefinida,2532736006.82422,316863.885559652
-107,Coquimbo,Activa,Comuna completa,2020-07-27 22:00:00,,4102,Aplicada a la totalidad de la comuna de forma indefinida,1914337722.45117,350322.520496572
+ID,Nombre,Estado,Alcance,Fecha de Inicio,Fecha de Término,Código CUT Comuna,Detalle,Superficie en m2,Perímetro en m,Region,n_REGION
+1,Arica,Histórica,Área Urbana Completa,4/16/2020 22:00,5/15/2020 22:00,15101,Corresponde al Radio Urbano de la Ciudad de Arica incluyendo la población San Miguel de Azapa,28050418.8,48722.30001,15,R15
+2,Santiago Norte,Histórica,Sector Específico,4/13/2020 5:00,5/5/2020 22:00,13101,Corresponde a la extensión de la cuarentena en la comuna de Santiago con límite en la línea contínua de las calles Av.Matta y Blanco Encalada,19939218.57,21599.35134,13,R13
+3,Puente Alto Poniente,Histórica,Sector Específico,4/9/2020 22:00,5/8/2020 22:00,13201,Corresponde al sector delimitado por la Av. Concha y Toro hacia el poniente. Se extiende posterior al término hacia el oriente hasta el Canal San Carlos,42364268.21,30428.05152,13,R13
+4,El Bosque,Activa,Comuna completa,4/16/2020 22:00,9/11/2020 22:00,13105,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,20622713.23,18788.87075,13,R13
+5,San Bernardo Nororiente,Histórica,Sector Específico,4/16/2020 22:00,5/8/2020 22:00,13401,"Corresponde al sector delimitado por los limites comunales y al interior en Av. Colon, Av. Balmaceda y Autopista Central. Se extiende alcance de cuarentena a la linea comprendida entre Camino el Mariscal y Avenida San Jose",16326216.83,24929.14572,13,R13
+6,Chillán,Histórica,Área Urbana Completa,3/30/2020 21:00,4/23/2020 22:00,16101,Aplica solo hasta el límite urbano de la ciudad,37835429.37,49337.02457,16,R16
+7,Osorno,Histórica,Área Urbana Completa,3/30/2020 21:00,4/30/2020 22:00,10301,Aplica solo hasta el límite urbano de la ciudad,42268789.14,59804.16284,10,R10
+8,Punta Arenas,Histórica,Área Urbana Completa,4/1/2020 21:00,5/7/2020 22:00,12101,Aplica a la zona urbana de la ciudad de Punta Arenas,112704517.1,77228.2049,12,R12
+9,Nueva Imperial,Histórica,Área Urbana Completa,4/9/2020 22:00,4/16/2020 0:00,9111,Aplica solo hasta el límite urbano de la ciudad,5981050.973,16614.82238,9,R09
+10,Lo Barnechea,Histórica,Área Urbana Completa,3/26/2020 21:00,4/13/2020 5:00,13115,Aplica solo hasta el límite urbano de la ciudad,94313826.98,56084.00806,13,R13
+11,Vitacura,Histórica,Comuna completa,3/26/2020 21:00,4/13/2020 5:00,13132,Aplicada a la totalidad de la comuna,40092348.38,30500.05847,13,R13
+12,Las Condes,Histórica,Comuna completa,3/26/2020 21:00,4/16/2020 22:00,13114,Aplicada a la totalidad de la comuna,144758813,60443.76785,13,R13
+13,Providencia,Histórica,Comuna completa,3/26/2020 21:00,4/13/2020 5:00,13123,Aplicada a la totalidad de la comuna,20592014.89,19208.88496,13,R13
+14,Ñuñoa Norte,Histórica,Sector Específico,4/13/2020 5:00,5/7/2020 22:00,13120,Corresponde a la extensión de la cuarentena en la comuna de Ñuñoa con límite en Av. Grecia,16724738.76,19686.67452,13,R13
+15,Hualpén,Histórica,Área Urbana Completa,3/30/2020 21:00,4/16/2020 22:00,8112,Aplica solo hasta el límite urbano de la ciudad,18355421.28,29232.35392,8,R08
+16,San Pedro de la Paz,Histórica,Área Urbana Completa,3/30/2020 21:00,4/16/2020 22:00,8108,Aplica solo hasta el límite urbano de la ciudad,44074427.26,57975.68294,8,R08
+17,Temuco,Histórica,Área Urbana Completa,3/28/2020 21:00,4/30/2020 22:00,9101,Aplica solo hasta el límite urbano de la ciudad,101423669.5,129552.6262,9,R09
+18,Santiago,Histórica,Comuna completa,3/26/2020 21:00,4/13/2020 5:00,13101,Aplicada a la totalidad de la comuna,33432633.32,28873.19656,13,R13
+19,Ñuñoa,Histórica,Comuna completa,3/26/2020 21:00,4/13/2020 5:00,13120,Aplicada a la totalidad de la comuna,24305861.12,21540.58821,13,R13
+20,Chillán viejo,Histórica,Área Urbana Completa,3/30/2020 21:00,4/23/2020 22:00,16103,Aplica solo hasta el límite urbano de la ciudad,10541904.53,16827.67264,16,R16
+21,Padre Las Casas,Histórica,Área Urbana Completa,3/27/2020 23:00,4/16/2020 0:00,9112,Aplica solo hasta el límite urbano de la ciudad,11026951.79,16203.40655,9,R09
+22,Rapa Nui,Histórica,Comuna completa,3/19/2020 23:00,4/6/2020 5:00,5201,Aplicada a la totalidad de la comuna,205901011.1,79899.08232,5,R05
+23,Independencia,Histórica,Comuna completa,3/26/2020 21:00,4/2/2020 21:00,13108,Aplicada a la totalidad de la comuna,10582914.04,13699.91284,13,R13
+24,Puerto Williams,Histórica,Área Urbana Completa,3/22/2020 23:00,4/6/2020 5:00,12201,Aplica solo hasta el límite urbano de la ciudad,2973458.348,9302.184402,12,R12
+25,Caleta Tortel,Histórica,Sector Específico,3/12/2020 21:00,3/27/2020 21:00,11303,Aplicada a la localidad de Caleta Tortel de forma preventiva por brotes de COVID-19 en Aysén,15336560.52,25455.56536,11,R11
+26,Quinta Normal,Activa,Comuna completa,4/23/2020 22:00,9/11/2020 22:00,13126,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,17014139.15,21243.79702,13,R13
+27,Pedro Aguirre Cerda,Histórica,Comuna completa,4/23/2020 22:00,8/31/2020 5:00,13121,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,12625146.27,15651.71896,13,R13
+28,Independencia Sur (Re-ingreso),Histórica,Sector Específico,4/23/2020 22:00,4/30/2020 22:00,13108,"Corresponde al sector delimitado por la linea comprendida de las calles Gamero y Santos Dumont hacia el sur, se extiende a cuarentena total el 30 de abril",2460063.441,8284.041136,13,R13
+29,Victoria,Histórica,Área Urbana Completa,4/30/2020 22:00,5/15/2020 22:00,9211,Aplica solo hasta el límite urbano de la ciudad,9256998.914,36013.0185,9,R09
+30,Angol,Histórica,Área Urbana Completa,4/30/2020 22:00,5/15/2020 22:00,9201,Aplica solo hasta el límite urbano de la ciudad,16903887.63,56627.20461,9,R09
+31,San Ramon Sur,Histórica,Sector Específico,4/30/2020 22:00,5/8/2020 22:00,13131,Se aplica cuarentena en sector sur de la comuna delimitado por la Avenida Américo Vespucio. Se extiende posterior al término a una cuarentena de territorio completo,4606059.174,8714.799869,13,R13
+32,Estación Central,Histórica,Comuna completa,4/30/2020 22:00,8/17/2020 5:00,13106,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,20682566.49,22689.22747,13,R13
+33,Independencia Extensión a Total,Activa,Comuna completa,4/30/2020 22:00,9/11/2020 22:00,13108,Aplicada a la totalidad de la comuna. Extendida desde el sector sur a la comuna completa. Se incorpora a cuarentena del Gran Santiago,10582914.04,13699.91284,13,R13
+34,La Pintana Norte,Histórica,Sector Específico,4/30/2020 22:00,5/8/2020 22:00,13112,Se aplica cuarentena en el sector norte de la comuna delimitado por la Avenida el Observatorio hacia el norte. . Se extiende posterior al término a una cuarentena de territorio completo,4883155.135,12416.97784,13,R13
+35,Antofagasta,Histórica,Área Urbana Completa,5/5/2020 22:00,5/29/2020 22:00,2101,Aplica solo hasta el límite urbano de la ciudad,43532156.43,134484.1679,2,R02
+36,Mejillones,Histórica,Comuna completa,5/5/2020 22:00,5/29/2020 22:00,2102,Aplicada a la totalidad de la comuna,4230181343,395409.359,2,R02
+37,Recoleta,Histórica,Comuna completa,5/5/2020 22:00,9/7/2020 5:00,13127,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,22715640.52,22324.07478,13,R13
+38,Cerrillos,Histórica,Comuna completa,5/5/2020 22:00,8/31/2020 5:00,13102,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,24198337.66,25227.76948,13,R13
+39,Quilicura,Histórica,Sector Específico,5/5/2020 22:00,5/15/2020 22:00,13125,Delimitada por la linea ferroviaria que cruza la comuna hacia el poniente. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,60071059.16,32915.98951,13,R13
+40,Santiago Extensión a Total,Histórica,Comuna completa,5/5/2020 22:00,8/17/2020 5:00,13101,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,33329909.5,29265.43369,13,R13
+41,Cerro Navia,Activa,Comuna completa,5/8/2020 22:00,9/11/2020 22:00,13103,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,15975127.99,19974.24854,13,R13
+42,Conchalí,Activa,Comuna completa,5/8/2020 22:00,9/11/2020 22:00,13104,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,15979605.81,16815.79341,13,R13
+43,Lo Espejo,Activa,Comuna completa,5/8/2020 22:00,9/11/2020 22:00,13116,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,11886614.09,13762.07367,13,R13
+44,La Cisterna,Histórica,Comuna completa,5/8/2020 22:00,9/7/2020 5:00,13109,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,14401733.59,15356.42189,13,R13
+45,La Florida,Histórica,Comuna completa,5/8/2020 22:00,8/31/2020 5:00,13110,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,102214162.8,59430.2695,13,R13
+46,Peñalolen,Histórica,Comuna completa,5/8/2020 22:00,8/24/2020 5:00,13122,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,77293355.85,43926.36596,13,R13
+47,Lo Prado,Activa,Comuna completa,5/8/2020 22:00,9/11/2020 22:00,13117,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,9448923.365,12856.50229,13,R13
+48,Macul,Histórica,Comuna completa,5/8/2020 22:00,8/31/2020 5:00,13118,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,18517268.58,18417.81156,13,R13
+49,Renca,Activa,Comuna completa,5/8/2020 22:00,9/11/2020 22:00,13128,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,34181427.81,34681.93943,13,R13
+50,San Joaquín,Histórica,Comuna completa,5/8/2020 22:00,9/7/2020 5:00,13129,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,14337674.61,16946.38265,13,R13
+51,San Miguel,Histórica,Comuna completa,5/8/2020 22:00,9/7/2020 5:00,13130,Aplicada a la totalidad de la comuna. Se incorpora a cuarentena del Gran Santiago,13863805.71,16029.804,13,R13
+52,La Granja,Histórica,Comuna completa,5/8/2020 22:00,9/7/2020 5:00,13111,Aplicada a la totalidad de la comuna. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,14562829.46,16986.35563,13,R13
+53,La Pintana Extensión a Total,Activa,Comuna completa,5/8/2020 22:00,9/11/2020 22:00,13112,Se amplía a toda la comuna desde su extensión original. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,44005772.31,31961.02786,13,R13
+54,San Ramón Extensión a Total,Histórica,Comuna completa,5/8/2020 22:00,9/7/2020 5:00,13131,Se amplía a toda la comuna desde su extensión original. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,9061336.23,14097.96056,13,R13
+55,Puente Alto Poniente Extendido,Histórica,Sector Específico,5/8/2020 22:00,5/15/2020 22:00,13201,Se amplia desde el límite actual (Av. Concha y Toro) hacia el oriente con límite en el Canal San Carlos. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago,89693170.63,58094.38238,13,R13
+56,San Bernardo Nororiente Extendido,Histórica,Sector Específico,5/8/2020 22:00,5/15/2020 22:00,13401,"Corresponde al sector delimitado por los limites comunales y al interior a la linea comprendida entre Camino el Mariscal y Avenida San Jose, Av. Balmaceda y Autopista Central. Se incorpora y amplia a extensión total a cuarentena del Gran Santiago",22289080.88,27208.67228,13,R13
+57,Alto Hospicio,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,1107,Aplicada a la totalidad de la comuna,655133931.2,109806.645,1,R01
+58,Iquique,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,1101,Aplicada a la totalidad de la comuna,2636677588,473982.6968,1,R01
+59,Buin,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,13402,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,315447694.4,106661.4539,13,R13
+60,Pudahuel,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,13124,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,283948656.4,86170.57957,13,R13
+61,Colina,Histórica,Comuna completa,5/15/2020 22:00,7/28/2020 5:00,13301,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,1388393076,206066.8384,13,R13
+62,Lampa,Histórica,Comuna completa,5/15/2020 22:00,8/10/2020 5:00,13302,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,645813313.2,127669.5728,13,R13
+63,Huechuraba,Histórica,Comuna completa,5/15/2020 22:00,8/31/2020 5:00,13107,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,64546615.35,39133.12121,13,R13
+64,Las Condes Re-ingreso Total,Histórica,Comuna completa,5/15/2020 22:00,7/28/2020 5:00,13114,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,142593822.2,62012.73806,13,R13
+65,La Reina,Histórica,Comuna completa,5/15/2020 22:00,7/28/2020 5:00,13113,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,33764086.18,28525.52709,13,R13
+66,Lo Barnechea Re-ingreso total,Histórica,Comuna completa,5/15/2020 22:00,7/28/2020 5:00,13115,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,1469176024,179591.2064,13,R13
+67,Vitacura Re-ingreso Total,Histórica,Comuna completa,5/15/2020 22:00,7/28/2020 5:00,13132,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,40872314.09,31136.24808,13,R13
+68,Maipú,Histórica,Comuna completa,5/15/2020 22:00,8/31/2020 5:00,13119,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,198564410.6,73872.62586,13,R13
+69,Ñuñoa Re-ingreso Total,Histórica,Comuna completa,5/15/2020 22:00,7/28/2020 5:00,13120,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,24288323.77,21382.63827,13,R13
+70,Padre Hurtado,Histórica,Comuna completa,5/15/2020 22:00,8/24/2020 5:00,13604,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,117050935,61176.67148,13,R13
+71,Puente Alto Extensión a Total,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,13201,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,127531919,59827.71196,13,R13
+72,Quilicura Extensión a Total,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,13125,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,82391551.05,41916.25605,13,R13
+73,San Bernardo Extensión a Total,Activa,Comuna completa,5/15/2020 22:00,9/11/2020 22:00,13401,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,221119742.1,103398.3901,13,R13
+74,Providencia Re-ingreso total,Histórica,Comuna completa,5/15/2020 22:00,8/10/2020 5:00,13123,Incorporada como parte de la Cuarentena del Gran Santiago y Alrededores a todo el territorio,20727385.16,19429.19934,13,R13
+75,Lonquimay,Histórica,Comuna completa,5/22/2020 22:00,6/5/2020 22:00,9205,Aplicada a la totalidad por criterios de capacidad sanitaria y aumento sustantivo de casos,6426178804,454701.6799,9,R09
+76,San Antonio,Histórica,Comuna completa,6/9/2020 22:00,7/28/2020 5:00,5601,Aplicada a la totalidad de la comuna,576482915.4,154571.5061,5,R05
+77,Calama,Activa,Comuna completa,6/12/2020 22:00,9/11/2020 22:00,2201,Aplicada a la totalidad de la comuna,18278946181,705723.8382,2,R02
+78,Viña del Mar,Activa,Comuna completa,6/12/2020 22:00,9/11/2020 22:00,5109,Aplicada a la totalidad de la comuna,171902397.7,77155.89755,5,R05
+79,Valparaíso,Activa,Comuna completa,6/12/2020 22:00,9/11/2020 22:00,5101,Aplicada a la totalidad de la comuna,451856991.1,181454.8091,5,R05
+80,Pozo Almonte (Radio Urbano),Activa,Área Urbana Completa,6/12/2020 22:00,9/11/2020 22:00,1401,Aplicable solo a la zona urbana,2353288.24,15497.7726,1,R01
+81,San José de Maipo (Área Urbana),Histórica,Área Urbana Completa,6/12/2020 22:00,8/24/2020 5:00,13203,Aplicado solo al sector urbano entre el Estero El Almendro y el Estero San José,6372625.93,11333.78348,13,R13
+82,Melipilla (Área Urbana),Histórica,Área Urbana Completa,6/12/2020 22:00,8/10/2020 5:00,13501,Aplicable solo al centro urbano,14510740.23,62602.70481,13,R13
+83,Curacaví (Área Urbana),Histórica,Área Urbana Completa,6/12/2020 22:00,8/10/2020 5:00,13503,Aplicable solo al Centro Urbano,5514002.385,32755.13479,13,R13
+84,TilTil (Área Urbana),Histórica,Área Urbana Completa,6/12/2020 22:00,7/28/2020 5:00,13303,"Aplicable solo a la zona urbana de Til-Til, excluyendo el sector de Huertos Familiares",1906761.893,18048.12058,13,R13
+85,Peñaflor,Histórica,Comuna completa,6/12/2020 22:00,8/24/2020 5:00,13605,Aplicada a la totalidad de la comuna,100223974.6,46938.49717,13,R13
+86,Los Andes,Histórica,Comuna completa,6/19/2020 22:00,8/24/2020 5:00,5301,Aplicada a la totalidad de la comuna,1757629850,274656.694,5,R05
+87,San Felipe,Histórica,Comuna completa,6/19/2020 22:00,7/28/2020 5:00,5701,Aplicada a la totalidad de la comuna,264868542.7,115232.8493,5,R05
+88,Rancagua,Histórica,Comuna completa,6/19/2020 22:00,8/10/2020 5:00,6101,Aplicada a la totalidad de la comuna,382965176.2,98686.23157,6,R06
+89,Machalí,Histórica,Comuna completa,6/19/2020 22:00,8/10/2020 5:00,6108,Aplicada a la totalidad de la comuna,3813690684,346676.4677,6,R06
+90,Curicó (Área Urbana),Histórica,Área Urbana Completa,6/19/2020 22:00,8/24/2020 5:00,7301,Aplicado solamente a la zona urbana,32069120.29,29295.20996,7,R07
+91,Antofagasta Re-ingreso Ciudad,Activa,Área Urbana Completa,6/23/2020 22:00,9/11/2020 22:00,2101,Re-ingreso total por incremento de casos activos. Alcance urbano acorde a Res.Ex. MINSAL 479/2020,43532156.43,134484.1679,2,R02
+92,Mejillones Re-ingreso urbano,Activa,Área Urbana Completa,6/23/2020 22:00,9/11/2020 22:00,2102,Re-ingreso total por incremento de casos activos. Alcance solo a área urbana acorde a Res.Ex. MINSAL 479/2020,7391563.771,35405.5397,2,R02
+93,Tocopilla,Histórica,Área Urbana Completa,6/23/2020 22:00,8/10/2020 5:00,2301,Aplicada solo a la extensión urbana de la comuna conforme a Res.Ex. MINSAL 479/2020,5375471.313,31002.88417,2,R02
+94,Quillota,Activa,Comuna completa,6/26/2020 22:00,9/11/2020 22:00,5501,Aplicada a la totalidad de la comuna,428867542.9,107405.4383,5,R05
+95,Graneros,Histórica,Comuna completa,6/26/2020 22:00,8/10/2020 5:00,6106,Aplicada a la totalidad de la comuna,164012497.7,67214.97939,6,R06
+96,Calera de Tango,Histórica,Comuna completa,6/26/2020 22:00,8/31/2020 5:00,13403,Aplicada a la totalidad de la comuna,105783369.8,54220.99288,13,R13
+97,El Monte,Histórica,Comuna completa,6/26/2020 22:00,8/31/2020 5:00,13602,Aplicada a la totalidad de la comuna,166257629.5,59682.03477,13,R13
+98,Talagante,Histórica,Comuna completa,6/26/2020 22:00,8/31/2020 5:00,13601,Aplicada a la totalidad de la comuna,183307247,81310.10226,13,R13
+99,Arica Re-Ingreso urbano,Activa,Área Urbana Completa,7/14/2020 22:00,9/11/2020 22:00,15101,Corresponde al Re-ingreso del Radio Urbano de la Ciudad de Arica,28050418.8,48722.30001,15,R15
+100,Rengo,Histórica,,7/14/2020 22:00,9/2/2020 5:00,6115,,,,6,R06
+101,Copiapó,Activa,,7/27/2020 22:00,9/11/2020 22:00,3101,,,,3,R03
+102,La Calera,Activa,,7/27/2020 22:00,9/11/2020 22:00,5502,,,,5,R05
+103,La Cruz,Activa,,7/27/2020 22:00,9/11/2020 22:00,5504,,,,5,R05
+104,Isla de Maipo,Activa,,7/27/2020 22:00,9/11/2020 22:00,13603,,,,13,R13
+105,Puerto Montt,Activa,,7/29/2020 22:00,9/11/2020 22:00,10101,,,,10,R10
+106,La Serena,Activa,,7/29/2020 22:00,9/11/2020 22:00,4101,,,,4,R04
+107,Coquimbo,Activa,,7/29/2020 22:00,9/11/2020 22:00,4102,,,,4,R04
+108,Tierra Amarilla,Activa,,8/10/2020 5:00,9/11/2020 22:00,3103,,,,3,R03
+109,San Vicente de Tagua Tagua,Activa,,8/14/2020 22:00,9/11/2020 22:00,6117,,,,6,R06
+110,Punta Arenas Re-ingreso,Activa,,8/21/2020 23:00,9/11/2020 22:00,12101,,,,12,R12
+111,Ovalle,Activa,,8/21/2020 23:00,9/11/2020 22:00,4301,,,,4,R04
+112,Penco,Activa,,8/21/2020 23:00,9/11/2020 22:00,8107,,,,8,R08
+113,Tomé,Activa,,8/21/2020 23:00,9/11/2020 22:00,8111,,,,8,R08
+114,Concepción,Activa,,8/28/2020 23:00,9/11/2020 22:00,8101,,,,8,R08
+115,Talcahuano,Activa,,8/28/2020 23:00,9/11/2020 22:00,8110,,,,8,R08
+116,Chiguayante,Activa,,8/28/2020 23:00,9/11/2020 22:00,8103,,,,8,R08
+117,Hualpén,Activa,,8/28/2020 23:00,9/11/2020 22:00,8112,,,,8,R08
+118,Linares,Activa,,8/28/2020 23:00,9/11/2020 22:00,7401,,,,7,R07
+119,Santa Cruz,Activa,,9/2/2020 5:00,9/11/2020 22:00,6310,,,,6,R06
+120,Chillán,Activa,,9/2/2020 5:00,9/11/2020 22:00,16101,,,,16,R16
+121,Chillán viejo,Activa,,9/2/2020 5:00,9/11/2020 22:00,16103,,,,16,R16
+122,Hualquí,Activa,,9/2/2020 5:00,9/11/2020 22:00,8105,,,,8,R08

--- a/output/producto29/README.md
+++ b/output/producto29/README.md
@@ -46,11 +46,17 @@ Variable: días miércoles para cambios en áreas, días viernes para cambio de 
 
 # Notas de Versión
 
+**09-09-2020**
+- Pull request de actualización de DataScienceUDD
+- Se agregan cuarentenas hasta el dia 20200909, sólo se modifica el archivo `Cuarentenas-Totales.csv`.
+- No se modifican las columnas `detalle`, `superficie en m` ni `perímetro en m`, ya que no conocemos la metodología de los autores originales.
+- El pull request se hace para mantener funcionando el código del IM de DataScienceUDD, ver Producto 33
+
 **03-08-2020**
 - Se ajustan fechas de prórroga de cuarentenas vigentes a Indefinidas en conformidad con Res.Ex. 606 de 29 de julio
 - Se ajustan cuarentenas notificadas en Res.Ex. 593 del 24 de julio de 2020
-    - Término de Cuarentenas de San Antonio, San Felipe, Vitacura, Las Condes, Lo Barnechea, Ñuñoa, La Reina, Colina y Til Til
-    - Incorporación de cuarentenas de Copiapó, Coquimbo, La Serena, La Calera, LA Cruz, Isla de Maipo y Puerto Montt
+	- Término de Cuarentenas de San Antonio, San Felipe, Vitacura, Las Condes, Lo Barnechea, Ñuñoa, La Reina, Colina y Til Til
+	- Incorporación de cuarentenas de Copiapó, Coquimbo, La Serena, La Calera, LA Cruz, Isla de Maipo y Puerto Montt
 
 **24-07-2020**
 - Se ajustan fechas de prórroga de cuarentenas vigentes en conformidad con Res.Ex. 575 del 22 de julio
@@ -59,7 +65,7 @@ Variable: días miércoles para cambios en áreas, días viernes para cambio de 
 - Se ajustan fechas de prórroga de cuarentenas vigentes.
 
 **15-07-2020**<br>
-- Cambio de Estado en Cuarentenas Futuras a Activas (2) 
+- Cambio de Estado en Cuarentenas Futuras a Activas (2)
 
 **13-07-2020**
 - Se incorporan Cuarentenas notificadas (Res.Ex. MINSAL 522 de 12 de julio de 2020) para el Radio Urbano de Arica (Re-ingreso) y Comuna de Rengo
@@ -81,7 +87,7 @@ Variable: días miércoles para cambios en áreas, días viernes para cambio de 
 - Se ajustan fechas de prórroga de cuarentenas vigentes en conformidad con Res.Ex. MINSAL 479 punto 1
 
 **19-06-2020 rev2**<br>
-- Cambio de Estado en Cuarentenas Futuras a Activas (5) 
+- Cambio de Estado en Cuarentenas Futuras a Activas (5)
 
 **19-06-2020**<br>
 - Corrección de delimitación de cuarentena ID 90 (Curicó Urbano) en base a cartografía dispuesta por el Jefe de la Defensa Nacional Región del Maule
@@ -92,10 +98,10 @@ Variable: días miércoles para cambios en áreas, días viernes para cambio de 
 - Se incorporan Cuarentenas decretadas en Res.Ex. MINSAL 467 del 17 de junio punto 2  (San Felipe, Los Andes, Rancagua, Machalí, Curicó Urbano)
 - Se ajustan fechas de prórroga de cuarentenas en conformidad con punto 1 de la resolución antes mencionada
 
-**12-06-2020**<br> 
-- Cambio de Estado en Cuarentenas Futuras a Activas (9) 
+**12-06-2020**<br>
+- Cambio de Estado en Cuarentenas Futuras a Activas (9)
 
-**11-06-2020**<br> 
+**11-06-2020**<br>
 - En conformidad con Res.Ex. MINSAL 424 del 7 de junio se cambia la catergoría de la cuarentena ID 77 (Calama) de "Área Urbana Completa" a "Comuna Completa" modificando el área en el archivo GeoJSON
 - Se incorporan Cuarentenas decretadas en Res.Ex. MINSAL 448 del 10 de junio punto 3.
 - Se ajustan fechas de prórroga de cuarentenas


### PR DESCRIPTION
Dada la importancia de este producto 29 para el funcionamiento de los índices de movilidad, y por cuanto no se ha actualizado hace varios días, hemos decidido hacer un pull request con la versión de `Cuarentenas-Totales.csv` actualizado al 20200909.

Desafortunadamente no tenemos los RRHH para modificar todo el directorio, así que sólo `Cuarentenas-Totales.csv` fue modificado. Cualquier cosa, la version actualizada esá también en mi fork en https://github.com/leoferres/Datos-COVID19/tree/master/output/producto29

Por favor re-chequear por consistencia.