### PR TITLE
Updating cron time for vacunacion from 23:07 UTC to 1:07 UTC

### DIFF
--- a/.github/workflows/vacunacion.yml
+++ b/.github/workflows/vacunacion.yml
@@ -10,7 +10,7 @@ on:
 #        paths: 'input/ReporteDiario/*.csv'
 
     schedule:
-      - cron:  '7 23 * * *'
+      - cron:  '7 1 * * *'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Esta es una sugerencia. El cron actual está programado para las 23:07 UTC, pero la fuente de datos se actualiza alrededor de las 00:00 UTC, por lo que la configuración actual tendría un día de desfase.

Puse las 01:07 en vez de 00:00 solo para tener una hora de buffer en caso de que haya algún problema.