### PR TITLE
Update ISCI.py (Producto 51)

### DIFF
--- a/src/ISCI.py
+++ b/src/ISCI.py
@@ -43,10 +43,8 @@ def prod51(url, prod):
     regionName(df)
 
     #get each week Monday as date
-    df['Fecha'] = '2020-W' + df['Week'].astype(str) + '-1'
-
-    for i in range(len(df)):
-        df.at[i, 'Fecha'] = dt.datetime.strptime(df.at[i, 'Fecha'], "%Y-W%W-%w")
+    df['Fecha'] = df['Week'].apply(lambda w: "{}-W{}-1".format(2020 + w//54, w%54))
+    df['Fecha'] = pd.to_datetime(df['Fecha'], format="%Y-W%W-%w")
 
     ## This is the std product
     df.to_csv(prod + '/ISCI_std.csv', index=False)


### PR DESCRIPTION
Actualización al script que genera producto 51 proveniente de ISCI. El script original tenía el año 2020 declarado de forma explicita, lo que generaba un error al convertir a formato datetime. Esta nueva versión infiere el año a partir del número de semana, que se cuentan desde enero de 2020.