### PR TITLE
Workflow para productos 89 y 90

### DIFF
--- a/.github/workflows/vacunacion_casos.yml
+++ b/.github/workflows/vacunacion_casos.yml
@@ -4,8 +4,7 @@ on:
     push:
         branches: master
         paths: 'input/Vacunacion/*.csv'
-    workflow_dispatch:
-
+        
 jobs:
   Actualiza_producto_89_y_90:
     runs-on: ubuntu-latest
@@ -30,7 +29,7 @@ jobs:
           
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "::set-output name=date::$(date +'%d-%m-%Y')"
     
     - uses: stefanzweifel/git-auto-commit-action@v4.1.1
       with:

--- a/.github/workflows/vacunacion_casos.yml
+++ b/.github/workflows/vacunacion_casos.yml
@@ -1,0 +1,38 @@
+name: Actualiza_incidencia_vacunacion
+
+on:
+    push:
+        branches: master
+        paths: 'input/Vacunacion/*.csv'
+    workflow_dispatch:
+
+jobs:
+  Actualiza_producto_89_y_90:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+          python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: generate product 90
+      run: |
+          cd src
+          python vacunacion_casos.py
+
+    - uses: stefanzweifel/git-auto-commit-action@v4.1.1
+      with:
+        commit_message: "Added data from campaña de vacunacion"
+        file_pattern: output/*/*.csv
+        repository: .
+        commit_user_name: MinCiencia GitHub Actions Bot
+        commit_user_email: actions@github.com
+        commit_author: minciencia github bot <actions@github.com>

--- a/.github/workflows/vacunacion_casos.yml
+++ b/.github/workflows/vacunacion_casos.yml
@@ -23,16 +23,23 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: generate product 90
+    - name: Generate product 80 and 90
       run: |
           cd src
           python vacunacion_casos.py
-
+          
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    
     - uses: stefanzweifel/git-auto-commit-action@v4.1.1
       with:
-        commit_message: "Added data from campaña de vacunacion"
+        commit_message: "Balance incidencia en vacunados ${{ steps.date.outputs.date }}"
+        
         file_pattern: output/*/*.csv
+        
         repository: .
+        
         commit_user_name: MinCiencia GitHub Actions Bot
         commit_user_email: actions@github.com
         commit_author: minciencia github bot <actions@github.com>

--- a/output/producto90/incidencia_en_vacunados.csv
+++ b/output/producto90/incidencia_en_vacunados.csv
@@ -1,5 +1,5 @@
 semana_epidemiologica,sin_vac_casos,una_dosis_casos,dos_dosis_casos,dos_dosis_comp_casos,dosis_unica_casos,dosis_unica_comp_casos,dosis_ref_comp_casos,sin_vac_uci,una_dosis_uci,dos_dosis_uci,dos_dosis_comp_uci,dosis_unica_uci,dosis_unica_comp_uci,dosis_ref_comp_uci,sin_vac_fall,una_dosis_fall,dos_dosis_fall,dos_dosis_comp_fall,dosis_unica_fall,dosis_unica_comp_fall,dosis_ref_comp_fall,personas_con_una_dosis,personas_con_pauta_completa,personas_con_refuerzo
-1,28385,22,0,0,0,0,0,554,0,0,0,0,0,0,518,0,0,0,0,0,0,10709.0,0.0,0.0
+1,27385,22,0,0,0,0,0,554,0,0,0,0,0,0,518,0,0,0,0,0,0,10709.0,0.0,0.0
 2,28288,17,0,0,0,0,0,650,0,0,0,0,0,0,564,0,0,0,0,0,0,13810.0,8371.0,0.0
 3,28726,93,1,0,0,0,0,690,2,0,0,0,0,0,585,1,0,0,0,0,0,57005.0,8376.0,0.0
 4,25464,160,0,0,0,0,0,562,2,0,0,0,0,0,529,3,0,0,0,0,0,57043.0,10414.0,0.0

--- a/output/producto90/incidencia_en_vacunados.csv
+++ b/output/producto90/incidencia_en_vacunados.csv
@@ -1,5 +1,5 @@
 semana_epidemiologica,sin_vac_casos,una_dosis_casos,dos_dosis_casos,dos_dosis_comp_casos,dosis_unica_casos,dosis_unica_comp_casos,dosis_ref_comp_casos,sin_vac_uci,una_dosis_uci,dos_dosis_uci,dos_dosis_comp_uci,dosis_unica_uci,dosis_unica_comp_uci,dosis_ref_comp_uci,sin_vac_fall,una_dosis_fall,dos_dosis_fall,dos_dosis_comp_fall,dosis_unica_fall,dosis_unica_comp_fall,dosis_ref_comp_fall,personas_con_una_dosis,personas_con_pauta_completa,personas_con_refuerzo
-1,27385,22,0,0,0,0,0,554,0,0,0,0,0,0,518,0,0,0,0,0,0,10709.0,0.0,0.0
+1,28385,22,0,0,0,0,0,554,0,0,0,0,0,0,518,0,0,0,0,0,0,10709.0,0.0,0.0
 2,28288,17,0,0,0,0,0,650,0,0,0,0,0,0,564,0,0,0,0,0,0,13810.0,8371.0,0.0
 3,28726,93,1,0,0,0,0,690,2,0,0,0,0,0,585,1,0,0,0,0,0,57005.0,8376.0,0.0
 4,25464,160,0,0,0,0,0,562,2,0,0,0,0,0,529,3,0,0,0,0,0,57043.0,10414.0,0.0


### PR DESCRIPTION
Hola, el otro día estuve probando actualizar el producto 90 con un workflow de GitHub Actions, para poder obtener la data más reciente posible sin tener que descargar todo el repo y funcionó bien.

En una de esas les es útil automatizar la generación de estos productos, así que dejo este PR. ¿Qué dices @dna33? (Noté que subes manualmente esos productos)